### PR TITLE
fix generate a valid plex cert

### DIFF
--- a/synology_plex_cert_autorenew.sh
+++ b/synology_plex_cert_autorenew.sh
@@ -51,6 +51,7 @@ fi
 if expr "$generate_p12" "=" "true" > /dev/null; then
   echo "Generating the p12 certificate file..."
   openssl pkcs12 -export -out "$p12_file_path" \
+    -certpbe AES-256-CBC -keypbe AES-256-CBC -macalg SHA256 \
     -in "$letsencrypt_cert_folder/RSA-cert.pem" \
     -inkey "$letsencrypt_cert_folder/RSA-privkey.pem" \
     -certfile "$letsencrypt_cert_folder/RSA-fullchain.pem" \


### PR DESCRIPTION
PMS 1.32.0 updates our openSSL library to openSSL v3 and finally dumps the long-deprecated openSSL v2. that causes that the generated certs are not valid anymore
https://forums.plex.tv/t/1-32-0-6865-breaks-custom-ssl-certificate/836698/